### PR TITLE
Update Shepherding layout to account for current floorplan

### DIFF
--- a/layout.yaml
+++ b/layout.yaml
@@ -10,7 +10,7 @@ teams:
       - SWI
   - name: level-3-south
     display_name: Level 3 South
-    # T_6 to T_14 and T_17 on the floorplans
+    # T_6 to T_13 and T_17 on the floorplans
     teams:
       - ELC
       - QMC
@@ -20,12 +20,12 @@ teams:
       - CLY
       - CAT
       - CHW
-      - HAB
       - BRK
   - name: level-3-north
     display_name: Level 3 North
-    # T_15, T_16 and T_18 to T_22 on the floorplans
+    # T_14 to T_16 and T_18 to T_22 on the floorplans
     teams:
+      - HAB
       - MES
       - CCR
       - SCS

--- a/layout.yaml
+++ b/layout.yaml
@@ -24,7 +24,7 @@ teams:
       - BRK
   - name: level-3-north
     display_name: Level 3 North
-    # T_15, T_16 and T_18 to T_23 on the floorplans
+    # T_15, T_16 and T_18 to T_22 on the floorplans
     teams:
       - MES
       - CCR
@@ -35,7 +35,7 @@ teams:
       - SEN
   - name: level-4-concourse
     display_name: Level 4 Concours
-    # T_24 to T_31 on the floorplans
+    # T_23 to T_30 on the floorplans
     teams:
       - DCG
       - GRD


### PR DESCRIPTION
This is in response to https://github.com/srobo/comp-floorplans/pull/9

This PR update the comments with pit ids and evens out the shepherds workload