### PR TITLE
Rejig shepherds based on new event layout

### DIFF
--- a/layout.yaml
+++ b/layout.yaml
@@ -1,7 +1,6 @@
 teams:
   - name: level-2-bar
     display_name: Level 2 Bar
-    # T_1 to T_5 on the floorplans
     teams:
       - HSO
       - BPV
@@ -10,7 +9,6 @@ teams:
       - SWI
   - name: level-3-south
     display_name: Level 3 South
-    # T_6 to T_13 on the floorplans
     teams:
       - QMC
       - WGS
@@ -21,7 +19,6 @@ teams:
       - HAB
   - name: level-3-north
     display_name: Level 3 North
-    # T_14 to T_16 and T_18 to T_22 on the floorplans
     teams:
       - MES
       - CCR
@@ -33,7 +30,6 @@ teams:
       - BRK
   - name: level-4-concourse
     display_name: Level 4 Concours
-    # T_23 to T_29 on the floorplans
     teams:
       - DCG
       - GRD

--- a/layout.yaml
+++ b/layout.yaml
@@ -12,26 +12,25 @@ teams:
     display_name: Level 3 South
     # T_6 to T_13 on the floorplans
     teams:
-      - ELC
       - QMC
       - WGS
       - GDC
       - CGS
       - CLY
       - CAT
-      - BRK
+      - HAB
   - name: level-3-north
     display_name: Level 3 North
     # T_14 to T_16 and T_18 to T_22 on the floorplans
     teams:
-      - HAB
       - MES
       - CCR
-      - SCS
       - BLB
       - TLC
       - CRB
       - SEN
+      - ELC
+      - BRK
   - name: level-4-concourse
     display_name: Level 4 Concours
     # T_23 to T_29 on the floorplans

--- a/league.yaml
+++ b/league.yaml
@@ -2,168 +2,168 @@ matches:
   0:
     main: [null, HSO, BPV, KDE]
   1:
-    main: [LSS, SWI, ELC, QMC]
+    main: [LSS, SWI, QMC, WGS]
   2:
-    main: [WGS, GDC, CGS, CLY]
+    main: [GDC, CGS, CLY, CAT]
   3:
-    main: [CAT, BRK, HAB, MES]
+    main: [HAB, MES, CCR, BLB]
   4:
-    main: [CCR, BLB, TLC, CRB]
+    main: [TLC, CRB, SEN, ELC]
   5:
-    main: [SEN, DCG, GRD, HAM]
+    main: [BRK, DCG, GRD, HAM]
   6:
     main: [HRS, MAI, PSC, RDS]
   7:
-    main: [HAM, ELC, CAT, GDC]
+    main: [HAM, QMC, HAB, CGS]
   8:
-    main: [WGS, QMC, BLB, BRK]
+    main: [GDC, WGS, CRB, MES]
   9:
-    main: [HAB, CCR, SEN, CRB]
+    main: [CCR, TLC, BRK, ELC]
   10:
-    main: [MAI, LSS, CLY, HSO]
+    main: [MAI, LSS, CAT, HSO]
   11:
-    main: [KDE, CGS, BPV, HRS]
+    main: [KDE, CLY, BPV, HRS]
   12:
-    main: [DCG, PSC, GRD, MES]
+    main: [DCG, PSC, GRD, BLB]
   13:
-    main: [TLC, RDS, SWI, null]
+    main: [SEN, RDS, SWI, null]
   14:
-    main: [MAI, SEN, DCG, BRK]
+    main: [MAI, BRK, DCG, MES]
   15:
-    main: [HRS, ELC, PSC, SWI]
+    main: [HRS, QMC, PSC, SWI]
   16:
-    main: [CRB, HSO, GDC, CCR]
+    main: [ELC, HSO, CGS, TLC]
   17:
-    main: [RDS, BPV, KDE, TLC]
+    main: [RDS, BPV, KDE, SEN]
   18:
-    main: [QMC, MES, null, CGS]
+    main: [WGS, BLB, null, CLY]
   19:
-    main: [WGS, HAM, BLB, GRD]
+    main: [GDC, HAM, CRB, GRD]
   20:
-    main: [LSS, CLY, CAT, HAB]
+    main: [LSS, CAT, HAB, CCR]
   21:
-    main: [ELC, null, RDS, DCG]
+    main: [QMC, null, RDS, DCG]
   22:
-    main: [HAM, QMC, CLY, CGS]
+    main: [HAM, WGS, CAT, CLY]
   23:
-    main: [BPV, LSS, GDC, CRB]
+    main: [BPV, LSS, CGS, ELC]
   24:
-    main: [MES, TLC, MAI, HAB]
+    main: [BLB, SEN, MAI, CCR]
   25:
-    main: [CCR, BRK, WGS, SEN]
+    main: [TLC, MES, GDC, BRK]
   26:
-    main: [KDE, HSO, HRS, BLB]
+    main: [KDE, HSO, HRS, CRB]
   27:
-    main: [GRD, SWI, CAT, PSC]
+    main: [GRD, SWI, HAB, PSC]
   28:
-    main: [RDS, TLC, HAB, CRB]
+    main: [RDS, SEN, CCR, ELC]
   29:
-    main: [BLB, BPV, CAT, DCG]
+    main: [CRB, BPV, HAB, DCG]
   30:
-    main: [CLY, HRS, null, QMC]
+    main: [CAT, HRS, null, WGS]
   31:
-    main: [MAI, WGS, SWI, LSS]
+    main: [MAI, GDC, SWI, LSS]
   32:
-    main: [CCR, GRD, HAM, GDC]
+    main: [TLC, GRD, HAM, CGS]
   33:
-    main: [BRK, MES, SEN, ELC]
+    main: [MES, BLB, BRK, QMC]
   34:
-    main: [PSC, CGS, KDE, HSO]
+    main: [PSC, CLY, KDE, HSO]
   35:
-    main: [BRK, MES, BPV, WGS]
+    main: [MES, BLB, BPV, GDC]
   36:
-    main: [CAT, GRD, ELC, RDS]
+    main: [HAB, GRD, QMC, RDS]
   37:
-    main: [BLB, HRS, CLY, SEN]
+    main: [CRB, HRS, CAT, BRK]
   38:
     main: [DCG, PSC, HSO, MAI]
   39:
-    main: [null, SWI, HAM, QMC]
+    main: [null, SWI, HAM, WGS]
   40:
-    main: [CRB, CGS, TLC, LSS]
+    main: [ELC, CLY, SEN, LSS]
   41:
-    main: [HAB, KDE, CCR, GDC]
+    main: [CCR, KDE, TLC, CGS]
   42:
-    main: [SWI, CRB, MAI, null]
+    main: [SWI, ELC, MAI, null]
   43:
     main: [KDE, DCG, HRS, RDS]
   44:
-    main: [CGS, CAT, LSS, PSC]
+    main: [CLY, HAB, LSS, PSC]
   45:
-    main: [BPV, GRD, QMC, HAM]
+    main: [BPV, GRD, WGS, HAM]
   46:
-    main: [GDC, TLC, BRK, SEN]
+    main: [CGS, SEN, MES, BRK]
   47:
-    main: [ELC, WGS, BLB, CLY]
+    main: [QMC, GDC, CRB, CAT]
   48:
-    main: [MES, HSO, HAB, CCR]
+    main: [BLB, HSO, CCR, TLC]
   49:
-    main: [QMC, SEN, DCG, TLC]
+    main: [WGS, BRK, DCG, SEN]
   50:
-    main: [CGS, ELC, CLY, null]
+    main: [CLY, QMC, CAT, null]
   51:
-    main: [LSS, PSC, CRB, GRD]
+    main: [LSS, PSC, ELC, GRD]
   52:
-    main: [CAT, MAI, WGS, RDS]
+    main: [HAB, MAI, GDC, RDS]
   53:
-    main: [BLB, CCR, MES, GDC]
+    main: [CRB, TLC, BLB, CGS]
   54:
-    main: [SWI, KDE, BRK, HSO]
+    main: [SWI, KDE, MES, HSO]
   55:
-    main: [HAB, BPV, HAM, HRS]
+    main: [CCR, BPV, HAM, HRS]
   56:
-    main: [CRB, WGS, null, BLB]
+    main: [ELC, GDC, null, CRB]
   57:
     main: [KDE, RDS, MAI, LSS]
   58:
-    main: [HSO, CLY, CCR, SWI]
+    main: [HSO, CAT, TLC, SWI]
   59:
-    main: [SEN, HAM, TLC, ELC]
+    main: [BRK, HAM, SEN, QMC]
   60:
-    main: [PSC, GDC, HAB, BPV]
+    main: [PSC, CGS, CCR, BPV]
   61:
-    main: [DCG, QMC, MES, BRK]
+    main: [DCG, WGS, BLB, MES]
   62:
-    main: [GRD, HRS, CGS, CAT]
+    main: [GRD, HRS, CLY, HAB]
   63:
-    main: [BPV, MAI, CCR, ELC]
+    main: [BPV, MAI, TLC, QMC]
   64:
-    main: [RDS, HAB, QMC, KDE]
+    main: [RDS, CCR, WGS, KDE]
   65:
-    main: [HRS, GRD, MES, TLC]
+    main: [HRS, GRD, BLB, SEN]
   66:
-    main: [GDC, HAM, CRB, CGS]
+    main: [CGS, HAM, ELC, CLY]
   67:
-    main: [SWI, CAT, WGS, BLB]
+    main: [SWI, HAB, GDC, CRB]
   68:
-    main: [null, BRK, HSO, CLY]
+    main: [null, MES, HSO, CAT]
   69:
-    main: [PSC, DCG, LSS, SEN]
+    main: [PSC, DCG, LSS, BRK]
   70:
-    main: [HSO, MES, RDS, BPV]
+    main: [HSO, BLB, RDS, BPV]
   71:
-    main: [CCR, CGS, HRS, BLB]
+    main: [TLC, CLY, HRS, CRB]
   72:
-    main: [CLY, null, DCG, MAI]
+    main: [CAT, null, DCG, MAI]
   73:
-    main: [QMC, KDE, SEN, CAT]
+    main: [WGS, KDE, BRK, HAB]
   74:
-    main: [GRD, HAB, LSS, BRK]
+    main: [GRD, CCR, LSS, MES]
   75:
-    main: [ELC, TLC, CRB, WGS]
+    main: [QMC, SEN, ELC, GDC]
   76:
-    main: [PSC, SWI, GDC, HAM]
+    main: [PSC, SWI, CGS, HAM]
   77:
-    main: [TLC, SEN, HRS, CAT]
+    main: [SEN, BRK, HRS, HAB]
   78:
-    main: [CGS, LSS, GRD, null]
+    main: [CLY, LSS, GRD, null]
   79:
-    main: [HSO, CRB, ELC, BPV]
+    main: [HSO, ELC, QMC, BPV]
   80:
-    main: [GDC, RDS, BRK, PSC]
+    main: [CGS, RDS, MES, PSC]
   81:
-    main: [WGS, CCR, SWI, MES]
+    main: [GDC, TLC, SWI, BLB]
   82:
-    main: [MAI, QMC, DCG, HAB]
+    main: [MAI, WGS, DCG, CCR]
   83:
-    main: [CLY, BLB, HAM, KDE]
+    main: [CAT, CRB, HAM, KDE]


### PR DESCRIPTION
See https://github.com/srobo/event-maps-2019/pull/2

This also removes the dropouts